### PR TITLE
deps(java): bump jackson-databind 2.17.2 → 2.18.9 (clears 4 Dependabot alerts)

### DIFF
--- a/clients/java/build.gradle.kts
+++ b/clients/java/build.gradle.kts
@@ -16,8 +16,8 @@ java {
 }
 
 dependencies {
-  api("com.fasterxml.jackson.core:jackson-databind:2.17.2")
-  api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.2")
+  api("com.fasterxml.jackson.core:jackson-databind:2.18.9")
+  api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.9")
   testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
   testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.11.4")
 }

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -37,12 +37,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.9</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.9</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## What

Bumps `com.fasterxml.jackson.core:jackson-databind` (and `jackson-datatype-jsr310`, in lockstep) from **2.17.2 → 2.18.9** in the Java client (`clients/java/pom.xml` and `clients/java/build.gradle.kts`).

## Why

Clears **4 Dependabot alerts** on `jackson-databind` flagged on the default branch (2 high, 2 moderate):

| # | Sev | Advisory | Vulnerable range | First patched |
|---|-----|----------|------------------|---------------|
| 57 | high | PolymorphicTypeValidator bypass via generic type parameters (arbitrary class instantiation) | `>= 2.10.0, <= 2.18.7` | 2.18.8 |
| 56 | high | Array subtype allowlist bypass in `BasicPolymorphicTypeValidator` (`allowIfSubTypeIsArray`) | `>= 2.10.0, < 2.18.8` | 2.18.8 |
| 58 | moderate | `InetSocketAddress` deserialization triggers eager DNS resolution (SSRF) | `>= 2.0.0, < 2.18.8` | 2.18.8 |
| 59 | moderate | Case-insensitive deserialization bypasses per-property `@JsonIgnoreProperties` | `>= 2.8.0, < 2.18.9` | 2.18.9 |

No `2.17.x` patch exists — the fixes only land in `2.18.8`+ — so `2.18.9` is the **minimal** version that clears all four alerts. `jackson-datatype-jsr310` is bumped to the same version to stay on one jackson train.

## Verification

- `mvn clean test` — 451 sources compiled against 2.18.9, both SDK tests pass (`GeneratedSdkSmokeTest`, `DiscriminatedUnionRoundTripTest`).
- `mvn dependency:tree` resolves the full jackson graph (databind / annotations / core / jsr310) to `2.18.9`, no `2.17.2` remaining.

## Generator note

These files are generated by the oagen Java emitter. The source-of-truth `JACKSON_VERSION` constant in the parent monorepo (`factory/generators/oagen/oagen-emitters/src/java/client.ts`) is bumped to `2.18.9` in a companion parent-repo change so a future regeneration does not revert this bump.
