### PR TITLE
fix(cli): reduce three DX frictions (--json, wph_ version-id guard, 404 org hint)

### DIFF
--- a/cli/cmd/cli_frictions_test.go
+++ b/cli/cmd/cli_frictions_test.go
@@ -1,0 +1,84 @@
+// Tests for the CLI-DX friction fixes:
+//   - `--json` shortcut for `--output json`            (root.go)
+//   - `versions get/diff/restore` rejecting a wph_ id  (workflows_versions.go)
+//   - an org hint appended to "... not found" 404s     (common.go)
+//
+// resolveWorkflowVersionRef lives in a `!retab_oagen_cli_workflows` file, so this
+// test file carries the same tag to stay out of the prototype (oagen) build.
+//go:build !retab_oagen_cli_workflows
+
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	retab "github.com/retab-dev/retab/clients/go"
+)
+
+// TestOutputJSONFlagShortcut: `--json` routes to `--output json`, and `--json=false`
+// is a no-op (never forces json), mirroring the existing `--output-table` shortcut.
+func TestOutputJSONFlagShortcut(t *testing.T) {
+	out := &outputFlagValue{}
+	f := &outputJSONFlagValue{output: out}
+	if !f.IsBoolFlag() {
+		t.Fatal("--json must present as a bool flag so `--json` needs no value")
+	}
+	if err := f.Set("true"); err != nil {
+		t.Fatalf("Set(true): %v", err)
+	}
+	if out.value != string(OutputJSON) {
+		t.Fatalf("--json should select json output, got %q", out.value)
+	}
+
+	out2 := &outputFlagValue{}
+	f2 := &outputJSONFlagValue{output: out2}
+	if err := f2.Set("false"); err != nil {
+		t.Fatalf("Set(false): %v", err)
+	}
+	if out2.value != "" {
+		t.Fatalf("--json=false must not change the format, got %q", out2.value)
+	}
+	if err := f2.Set("notabool"); err == nil {
+		t.Fatal("Set(notabool) must error")
+	}
+}
+
+// TestResolveWorkflowVersionRefRejectsPublishRecordID: a wph_ publish-record id is
+// caught locally with guidance (no server round-trip), while a real ver_ id passes
+// straight through. Both paths avoid any client call, so a nil client is safe.
+func TestResolveWorkflowVersionRefRejectsPublishRecordID(t *testing.T) {
+	_, err := resolveWorkflowVersionRef(context.Background(), nil, "wf_123", "wph_abcDEF")
+	if err == nil {
+		t.Fatal("a wph_ publish-record id must be rejected with guidance, not passed to the server")
+	}
+	for _, want := range []string{"publish-record", "workflow_version_id", "versions list"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("guidance should mention %q, got: %v", want, err)
+		}
+	}
+
+	got, err := resolveWorkflowVersionRef(context.Background(), nil, "wf_123", "ver_realid")
+	if err != nil || got != "ver_realid" {
+		t.Fatalf("a literal ver_ id must pass through untouched, got (%q, %v)", got, err)
+	}
+}
+
+// TestRenderAPIErrorAppendsOrgHintOn404NotFound: a 404 whose message reads
+// "... not found" gets an org-context hint appended; other statuses do not.
+func TestRenderAPIErrorAppendsOrgHintOn404NotFound(t *testing.T) {
+	cmd := commandWithDebugFlagForTest(t, false)
+
+	notFound := &retab.APIError{StatusCode: http.StatusNotFound, Message: "Workflow not found"}
+	got := renderAPIErrorForCLI(cmd, notFound)
+	if !strings.Contains(got, "org switch") || !strings.Contains(strings.ToLower(got), "different organization") {
+		t.Fatalf("a 404 not-found should append an org hint, got:\n%s", got)
+	}
+
+	badRequest := &retab.APIError{StatusCode: http.StatusBadRequest, Message: "bad thing"}
+	if strings.Contains(renderAPIErrorForCLI(cmd, badRequest), "org switch") {
+		t.Fatalf("a non-404 error must not get the org hint")
+	}
+}

--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -270,6 +270,16 @@ func renderAPIErrorForCLI(cmd *cobra.Command, apiErr *retab.APIError) string {
 	if apiErr.RequestID != "" {
 		lines = append(lines, "  Request-ID: "+apiErr.RequestID)
 	}
+	// A 404 "... not found" on a resource that plainly exists is, more often than a
+	// typo, the active organization having drifted (e.g. after a token refresh): the
+	// id is real but lives in an org you are not currently pointed at. The raw
+	// "not found" reads as data loss. Nudge toward the org check — cheaply, without
+	// asserting it (a genuine typo yields the same 404, and the advice still helps).
+	if apiErr.StatusCode == http.StatusNotFound && strings.Contains(strings.ToLower(message), "not found") {
+		lines = append(lines,
+			"  If you expect this to exist, it may belong to a different organization —",
+			"  check the active org with `retab org list` and switch with `retab org switch <org-id>`.")
+	}
 	return strings.Join(lines, "\n")
 }
 

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -305,6 +305,7 @@ func renderRootHelpWithStyles(w io.Writer, root *cobra.Command, s styles) {
 		{"--debug", "", "verbose debug output", ""},
 		{"--output", "FORMAT", "output format: json | table | csv (default: auto)", ""},
 		{"--output-table", "", "shortcut for --output table", ""},
+		{"--json", "", "shortcut for --output json", ""},
 		{"-h, --help", "", "show this help", ""},
 		{"-v, --version", "", "show version", ""},
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -48,6 +48,30 @@ func (o *outputTableFlagValue) Set(raw string) error {
 	return nil
 }
 
+// outputJSONFlagValue backs the `--json` shortcut, mirroring outputTableFlagValue.
+// `--json` is the spelling users reach for first (and the one this CLI's own help
+// examples imply); routing it to `--output json` avoids the "unknown flag: --json"
+// papercut without introducing a second source of truth for the format.
+type outputJSONFlagValue struct {
+	output *outputFlagValue
+}
+
+func (o *outputJSONFlagValue) String() string { return "false" }
+func (o *outputJSONFlagValue) Type() string   { return "bool" }
+func (o *outputJSONFlagValue) IsBoolFlag() bool {
+	return true
+}
+func (o *outputJSONFlagValue) Set(raw string) error {
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		return fmt.Errorf("invalid --json value %q", raw)
+	}
+	if enabled {
+		return o.output.Set(string(OutputJSON))
+	}
+	return nil
+}
+
 var rootOutputFlag = &outputFlagValue{}
 
 var rootCmd = &cobra.Command{
@@ -315,6 +339,10 @@ func init() {
 	rootCmd.PersistentFlags().Var(rootOutputFlag, "output", "output format: json | table | csv (default: auto-detect)")
 	rootCmd.PersistentFlags().Var(&outputTableFlagValue{output: rootOutputFlag}, "output-table", "shortcut for --output table")
 	if flag := rootCmd.PersistentFlags().Lookup("output-table"); flag != nil {
+		flag.NoOptDefVal = "true"
+	}
+	rootCmd.PersistentFlags().Var(&outputJSONFlagValue{output: rootOutputFlag}, "json", "shortcut for --output json")
+	if flag := rootCmd.PersistentFlags().Lookup("json"); flag != nil {
 		flag.NoOptDefVal = "true"
 	}
 	rootCmd.InitDefaultCompletionCmd()

--- a/cli/cmd/workflows_versions.go
+++ b/cli/cmd/workflows_versions.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	retab "github.com/retab-dev/retab/clients/go"
 	"github.com/spf13/cobra"
@@ -34,6 +35,14 @@ func resolveWorkflowVersionRef(ctx context.Context, client *retab.Client, workfl
 	case "draft":
 		return "", fmt.Errorf("%q is not a published version; the version commands operate on published versions only — inspect the draft with `retab workflows spec get %s` or `retab workflows blocks list %s`, or publish it first", ref, workflowID, workflowID)
 	default:
+		// A `wph_...` is a publish-RECORD id (the `id` field in `versions list`),
+		// not the version id these commands address. Passing it hits the server and
+		// 404s with a bare "version not found", which reads as "this version is
+		// gone" rather than "wrong id field". Catch it here and point at the id that
+		// actually works — the `workflow_version_id` (ver_...) in the same list row.
+		if strings.HasPrefix(ref, "wph_") {
+			return "", fmt.Errorf("%q is a publish-record id, not a version id — the version commands take the workflow_version_id (ver_...). Find it in `retab workflows versions list %s` (the WORKFLOW_VERSION_ID column, or the workflow_version_id field in JSON)", ref, workflowID)
+		}
 		return ref, nil
 	}
 }


### PR DESCRIPTION
## What
Three small, self-contained CLI developer-experience fixes, each surfaced while operating the CLI against real workflows.

1. **`--json` shortcut** for `--output json` — mirrors the existing `--output-table`. Reaching for `--json` first is common; today it errors with `unknown flag`.
2. **`workflows versions get/diff/restore` reject a `wph_` publish-record id** with guidance pointing at the `ver_...` `workflow_version_id`, instead of letting it hit the server and 404. The `versions list` JSON leads with the `wph_` `id`, so it's easy to grab the wrong one (the table output already leads with the ver_ id — this covers the JSON/default path).
3. **Org-context hint on `… not found` 404s** — a 404 on a resource that plainly exists is, more often than a typo, the active org having drifted (e.g. after a token refresh). Appends a non-asserting nudge toward `retab org list` / `retab org switch`.

## Tests
New `cmd/cli_frictions_test.go` covers all three (flag routing incl. the `--json=false` no-op, the `wph_` guard + `ver_` passthrough with no server round-trip, and the 404 hint firing only on not-found 404s). `go build ./...`, `go vet ./cmd/`, and the full `cmd` suite are green on the `main` base.

## Notes
- `--json=false` is a no-op, exactly like `--output-table`.
- No change to existing flags or behavior.
- `--help` now lists `--json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)